### PR TITLE
Fix Prefix and Suffix not working with PurePerms when provider type is MySQL

### DIFF
--- a/src/_64FF00/PureChat/PureChat.php
+++ b/src/_64FF00/PureChat/PureChat.php
@@ -41,6 +41,9 @@ class PureChat extends PluginBase
     /** @var Config $config */
     private $config;
 
+    /** @var Config $playerData */
+    private $playerData;
+
     /** @var FactionsInterface $factionsAPI */
     private $factionsAPI;
 
@@ -55,6 +58,7 @@ class PureChat extends PluginBase
         $this->saveDefaultConfig();
 
         $this->config = new Config($this->getDataFolder() . "config.yml", Config::YAML);
+        $this->playerData = new Config($this->getDataFolder() . "playerData.yml", Config::YAML);
 
         if(!$this->config->get("version"))
         {
@@ -616,16 +620,11 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            return $this->purePerms->getUserDataMgr()->getNode($player, "prefix");
+            return $this->playerData->getNested($player->getName() . "." . "default-prefix", "");
         }
         else
         {
-            $worldData = $this->purePerms->getUserDataMgr()->getWorldData($player, $levelName);
-
-            if(!isset($worldData["prefix"]) || $worldData["prefix"] === null)
-                return "";
-
-            return $worldData["prefix"];
+            return $this->playerData->getNested($player->getName() . "." . $levelName . "prefix");
         }
     }
 
@@ -638,16 +637,11 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            return $this->purePerms->getUserDataMgr()->getNode($player, "suffix");
+            return $this->playerData->getNested($player->getName() . "." . "default-suffix", "");
         }
         else
         {
-            $worldData = $this->purePerms->getUserDataMgr()->getWorldData($player, $levelName);
-
-            if(!isset($worldData["suffix"]) || $worldData["suffix"] === null)
-                return "";
-
-            return $worldData["suffix"];
+            return $this->playerData->getNested($player->getName() . "." . $levelName . "suffix");
         }
     }
 
@@ -709,15 +703,11 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            $this->purePerms->getUserDataMgr()->setNode($player, "prefix", $prefix);
+            $this->playerData->setNested($player->getName() . "." . "default-prefix", $prefix);
         }
         else
         {
-            $worldData = $this->purePerms->getUserDataMgr()->getWorldData($player, $levelName);
-
-            $worldData["prefix"] = $prefix;
-
-            $this->purePerms->getUserDataMgr()->setWorldData($player, $levelName, $worldData);
+            $this->playerData->setNested($player->getName() . "." . $levelName . "prefix", $prefix);
         }
 
         return true;
@@ -733,15 +723,11 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            $this->purePerms->getUserDataMgr()->setNode($player, "suffix", $suffix);
+            $this->playerData->setNested($player->getName() . "." . "default-suffix", $suffix);
         }
         else
         {
-            $worldData = $this->purePerms->getUserDataMgr()->getWorldData($player, $levelName);
-
-            $worldData["suffix"] = $suffix;
-
-            $this->purePerms->getUserDataMgr()->setWorldData($player, $levelName, $worldData);
+            $this->playerData->setNested($player->getName() . "." . $levelName . "suffix", $suffix);
         }
 
         return true;

--- a/src/_64FF00/PureChat/PureChat.php
+++ b/src/_64FF00/PureChat/PureChat.php
@@ -620,7 +620,7 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            return $this->playerData->getNested($player->getName() . "." . "default-prefix", "");
+            return $this->playerData->getNested($player->getName() . ".default.prefix", "");
         }
         else
         {
@@ -637,7 +637,7 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            return $this->playerData->getNested($player->getName() . "." . "default-suffix", "");
+            return $this->playerData->getNested($player->getName() . ".default.suffix", "");
         }
         else
         {
@@ -703,7 +703,7 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            $this->playerData->setNested($player->getName() . "." . "default-prefix", $prefix);
+            $this->playerData->setNested($player->getName() . ".default.prefix", $prefix);
         }
         else
         {
@@ -723,7 +723,7 @@ class PureChat extends PluginBase
     {
         if($levelName === null)
         {
-            $this->playerData->setNested($player->getName() . "." . "default-suffix", $suffix);
+            $this->playerData->setNested($player->getName() . ".default.suffix", $suffix);
         }
         else
         {

--- a/src/_64FF00/PureChat/PureChat.php
+++ b/src/_64FF00/PureChat/PureChat.php
@@ -704,10 +704,12 @@ class PureChat extends PluginBase
         if($levelName === null)
         {
             $this->playerData->setNested($player->getName() . ".default.prefix", $prefix);
+            $this->playerData->save();
         }
         else
         {
             $this->playerData->setNested($player->getName() . "." . $levelName . "prefix", $prefix);
+            $this->playerData->save();
         }
 
         return true;
@@ -724,10 +726,12 @@ class PureChat extends PluginBase
         if($levelName === null)
         {
             $this->playerData->setNested($player->getName() . ".default.suffix", $suffix);
+            $this->playerData->save();
         }
         else
         {
             $this->playerData->setNested($player->getName() . "." . $levelName . "suffix", $suffix);
+            $this->playerData->save();
         }
 
         return true;


### PR DESCRIPTION
This is a breaking change and will require users to update any previously set Prefix and Suffix data.  These items have now been moved to a playerData.yml file in the PureChat data directory.  Previously, this information was saved in PurePerms (yes PurePerms not PureChat) in individual player files. The data format for playerData.yml is as follows:

```yaml
playername:
  default:
    - prefix: "MyPrefix"
    - suffix: "ASuffix"
  world:
    - prefix: "WorldSpecificPrefix"
    - suffix: "WorldSpecificSuffix"
  world2:
    - prefix: "PrefixForWorld2"
    - suffix: "SuffixForWorld2"
  
```